### PR TITLE
Add `playPauseByState` handler and `POST /play-pause` route

### DIFF
--- a/controllers/media.controller.js
+++ b/controllers/media.controller.js
@@ -10,6 +10,38 @@ exports.togglePlayPause = (req, res) => {
   lgtv.on("error", () => res.status(500).send("Error al conectar con el televisor"));
 };
 
+exports.playPauseByState = (req, res) => {
+  const lgtv = require("../utils/lgtv")();
+  lgtv.on("connect", () => {
+    lgtv.request("ssap://media.controls/getPlayState", (err, response) => {
+      if (err) {
+        return res.status(500).send("No se pudo obtener el estado de reproducción");
+      }
+
+      const playState = response?.playState;
+      let command;
+      let successMessage;
+
+      if (playState === "playing") {
+        command = "ssap://media.controls/pause";
+        successMessage = "Comando pause enviado correctamente";
+      } else if (playState === "paused") {
+        command = "ssap://media.controls/play";
+        successMessage = "Comando play enviado correctamente";
+      } else {
+        return res.status(400).send("Estado de reproducción no soportado");
+      }
+
+      lgtv.request(command, (err2) => {
+        if (err2) return res.status(500).send("No se pudo enviar el comando");
+        res.send(successMessage);
+        lgtv.disconnect();
+      });
+    });
+  });
+  lgtv.on("error", () => res.status(500).send("Error al conectar con el televisor"));
+};
+
 
 exports.playOrStart = (req, res) => {
   const lgtv = require("../utils/lgtv")();
@@ -75,4 +107,3 @@ exports.openDisneyPlus = (req, res) => {
     res.status(500).send("No se pudo conectar al televisor");
   });
 };
-

--- a/routes/media.routes.js
+++ b/routes/media.routes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const mediaController = require("../controllers/media.controller");
 
 router.post("/toggle", mediaController.togglePlayPause);
+router.post("/play-pause", mediaController.playPauseByState);
 router.post("/play-or-start", mediaController.playOrStart);
 router.post("/disney", mediaController.openDisneyPlus);
 


### PR DESCRIPTION
### Motivation
- Provide a handler that queries the current playback state and issues the appropriate play or pause command instead of blindly toggling.
- Keep connection/error handling consistent with existing media handlers by reusing `utils/lgtv` event handling.
- Return clearer responses indicating whether `play` or `pause` was sent.

### Description
- Added `playPauseByState` in `controllers/media.controller.js` which connects to `utils/lgtv`, calls `ssap://media.controls/getPlayState`, and inspects the `playState` field.
- The handler sends `ssap://media.controls/pause` when `playState === "playing"` and `ssap://media.controls/play` when `playState === "paused"`, and returns an error for unsupported states.
- Errors and disconnection are handled consistently with the existing `togglePlayPause` handler and the handler sends a success message indicating `play` or `pause` was sent.
- Registered a new route `POST /play-pause` in `routes/media.routes.js` that maps to `playPauseByState`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfa7aa4c883328667e3d20420071f)