### PR TITLE
Add alias routes for remote media control and refine play/pause handlers

### DIFF
--- a/controllers/media.controller.js
+++ b/controllers/media.controller.js
@@ -1,13 +1,82 @@
 exports.togglePlayPause = (req, res) => {
   const lgtv = require("../utils/lgtv")();
+
+  const respondAndDisconnect = (status, message) => {
+    res.status(status).send(message);
+    lgtv.disconnect();
+  };
+
+  const fallbackToggle = () => {
+    lgtv.request("ssap://media.controls/togglePause", (toggleErr) => {
+      if (toggleErr) return respondAndDisconnect(500, "No se pudo alternar reproducción/pausa");
+      respondAndDisconnect(200, "Comando togglePause enviado correctamente");
+    });
+  };
+
   lgtv.on("connect", () => {
-    lgtv.request("ssap://media.controls/togglePause", (err) => {
-      if (err) return res.status(500).send("No se pudo alternar reproducción/pausa");
-      res.send("Comando togglePause enviado correctamente");
-      lgtv.disconnect();
+    lgtv.request("ssap://com.webos.service.ime/sendEnterKey", { key: "ENTER" }, () => {
+      setTimeout(() => {
+        lgtv.request("ssap://media.controls/getPlaybackState", (stateErr, stateResponse = {}) => {
+          if (stateErr || !stateResponse.state) {
+            return fallbackToggle();
+          }
+
+          const playbackState = stateResponse.state;
+          const command =
+            playbackState === "playing" ? "ssap://media.controls/pause" : "ssap://media.controls/play";
+
+          lgtv.request(command, (commandErr) => {
+            if (commandErr) return fallbackToggle();
+            respondAndDisconnect(
+              200,
+              playbackState === "playing"
+                ? "✅ Reproducción pausada correctamente"
+                : "✅ Reproducción iniciada correctamente"
+            );
+          });
+        });
+      }, 600);
     });
   });
   lgtv.on("error", () => res.status(500).send("Error al conectar con el televisor"));
+};
+
+const sendRemoteButton = (buttonName, res, successMessage) => {
+  const lgtv = require("../utils/lgtv")();
+
+  const respondAndDisconnect = (status, message) => {
+    res.status(status).send(message);
+    lgtv.disconnect();
+  };
+
+  lgtv.on("connect", () => {
+    lgtv.getSocket(
+      "ssap://com.webos.service.networkinput/getPointerInputSocket",
+      (socketErr, socket) => {
+        if (socketErr || !socket) {
+          return respondAndDisconnect(500, "No se pudo abrir el control remoto");
+        }
+
+        const payload = JSON.stringify({ type: "button", name: buttonName });
+        socket.send(payload);
+        respondAndDisconnect(200, successMessage);
+      }
+    );
+  });
+
+  lgtv.on("error", () => res.status(500).send("Error al conectar con el televisor"));
+};
+
+exports.remotePlayPause = (req, res) => {
+  sendRemoteButton("PLAY_PAUSE", res, "✅ Comando remoto play/pause enviado");
+};
+
+exports.remotePlay = (req, res) => {
+  sendRemoteButton("PLAY", res, "✅ Comando remoto play enviado");
+};
+
+exports.remotePause = (req, res) => {
+  sendRemoteButton("PAUSE", res, "✅ Comando remoto pause enviado");
 };
 
 
@@ -75,4 +144,3 @@ exports.openDisneyPlus = (req, res) => {
     res.status(500).send("No se pudo conectar al televisor");
   });
 };
-

--- a/routes/media.routes.js
+++ b/routes/media.routes.js
@@ -5,6 +5,12 @@ const mediaController = require("../controllers/media.controller");
 router.post("/toggle", mediaController.togglePlayPause);
 router.post("/play-or-start", mediaController.playOrStart);
 router.post("/disney", mediaController.openDisneyPlus);
+router.post("/remote-playpause", mediaController.remotePlayPause);
+router.post("/remote-play", mediaController.remotePlay);
+router.post("/remote-pause", mediaController.remotePause);
+router.post("/playpause", mediaController.remotePlayPause);
+router.post("/play", mediaController.remotePlay);
+router.post("/pause", mediaController.remotePause);
 
 
 module.exports = router;


### PR DESCRIPTION
### Motivation
- Provide simple alias endpoints to make functional testing of remote media controls easier. 
- Expose explicit `play`/`pause`/`playpause` routes that map to the existing remote control handlers. 
- Make play/pause behavior more deterministic by probing playback state and falling back to a toggle when needed. 

### Description
- Added alias routes `POST /media/playpause`, `POST /media/play`, and `POST /media/pause` in `routes/media.routes.js` that map to the existing handlers. 
- Added `sendRemoteButton(buttonName, res, successMessage)` helper and exported `remotePlayPause`, `remotePlay`, and `remotePause` controller actions to send pointer-socket remote commands. 
- Improved `togglePlayPause` to send `ssap://com.webos.service.ime/sendEnterKey`, query playback state via `ssap://media.controls/getPlaybackState`, call `ssap://media.controls/play` or `ssap://media.controls/pause` as appropriate, and use `ssap://media.controls/togglePause` as a fallback. 
- Centralized response/disconnect logic with `respondAndDisconnect` and standardized error handling on `lgtv.on("error")`. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0526e8f88332b081bcafb9bea998)