### PR TITLE
Add Docker Compose setup with Nginx proxy (expose on 8081)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+Dockerfile
+Dockerfile.*
+docker-compose.yml
+.git
+.gitignore
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=5000
+
+EXPOSE 5000
+
+CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  app:
+    build: .
+    container_name: backendwaketv-app
+    environment:
+      - NODE_ENV=production
+      - PORT=5000
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: backendwaketv-nginx
+    depends_on:
+      - app
+    ports:
+      - "8081:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,13 @@
+server {
+  listen 80;
+  server_name _;
+
+  location / {
+    proxy_pass http://app:5000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}


### PR DESCRIPTION
### Motivation
- Dockerizar la aplicación Node.js para poderla ejecutar en contenedores y facilitar despliegues reproducibles.
- Servir la aplicación detrás de un proxy Nginx para manejar conexiones y exponerla en el puerto `8081` del host.
- Evitar incluir archivos locales no deseados en la imagen usando `.dockerignore`.

### Description
- Añadidos `Dockerfile` y `.dockerignore` para construir una imagen de la aplicación con `node:20-alpine` y dependencias instaladas con `npm ci --omit=dev`.
- Añadido `nginx/default.conf` que define un `proxy_pass` a `http://app:5000` para enrutar las peticiones desde Nginx al servicio de la app.
- Añadido `docker-compose.yml` con los servicios `app` (build desde el repositorio) y `nginx` (imagen `nginx:1.27-alpine`) y mapeo de puertos `"8081:80"`.
- Configurado el contenedor de la app para usar `PORT=5000` y exponer `5000` en la imagen, y la configuración de Nginx montada en `/etc/nginx/conf.d/default.conf`.

### Testing
- No se ejecutaron pruebas automáticas en esta rama como parte de este cambio.
- Para validar manualmente la configuración se puede ejecutar `docker compose up --build -d` y comprobar la respuesta en `http://localhost:8081/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e12ac402883329521964eb9d014a0)