### PR TITLE
Fix WOL & Disney endpoints for Docker: host networking, env config, retries

### DIFF
--- a/config/tv.config.js
+++ b/config/tv.config.js
@@ -1,4 +1,6 @@
 module.exports = {
-  MAC_ADDRESS: "14:c9:13:7b:b7:14",
-  TV_IP: "192.168.18.19",
+  MAC_ADDRESS: process.env.TV_MAC_ADDRESS || "14:c9:13:7b:b7:14",
+  TV_IP: process.env.TV_IP || "192.168.18.19",
+  WOL_BROADCAST_ADDRESS: process.env.WOL_BROADCAST_ADDRESS || "255.255.255.255",
+  WOL_PORT: Number(process.env.WOL_PORT || 9),
 };

--- a/controllers/power.controller.js
+++ b/controllers/power.controller.js
@@ -1,15 +1,101 @@
 const wol = require("wol");
-const { MAC_ADDRESS } = require("../config/tv.config");
+const createLgtv = require("../utils/lgtv");
+const {
+  MAC_ADDRESS,
+  WOL_BROADCAST_ADDRESS,
+  WOL_PORT,
+} = require("../config/tv.config");
 
-exports.powerOn = (req, res) => {
-  wol.wake(MAC_ADDRESS, (err) => {
-    if (err) return res.status(500).send("Error al encender el televisor");
-    res.send("Encendiendo el televisor...");
+const DISNEY_APP_ID = "com.disney.disneyplus-prod";
+
+const wakeTv = () =>
+  new Promise((resolve, reject) => {
+    wol.wake(
+      MAC_ADDRESS,
+      {
+        address: WOL_BROADCAST_ADDRESS,
+        port: WOL_PORT,
+      },
+      (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve();
+      }
+    );
+  });
+
+const connectTv = () =>
+  new Promise((resolve, reject) => {
+    const lgtv = createLgtv();
+
+    const clear = () => {
+      lgtv.removeAllListeners("connect");
+      lgtv.removeAllListeners("error");
+    };
+
+    lgtv.once("connect", () => {
+      clear();
+      resolve(lgtv);
+    });
+
+    lgtv.once("error", (err) => {
+      clear();
+      try {
+        lgtv.disconnect();
+      } catch (_) {
+        // noop
+      }
+      reject(err);
+    });
+  });
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const connectWithRetry = async ({ attempts, delayMs }) => {
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await connectTv();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  throw lastError || new Error("No se pudo conectar con el TV");
+};
+
+const launchDisney = (lgtv, res) => {
+  lgtv.request("ssap://system.launcher/launch", { id: DISNEY_APP_ID }, (err) => {
+    if (err) {
+      console.error("❌ No se pudo abrir Disney+:", err);
+      res.status(500).send("El TV respondió, pero no se pudo abrir Disney+");
+    } else {
+      res.send("✅ Disney+ abierto correctamente");
+    }
+
+    lgtv.disconnect();
   });
 };
 
+exports.powerOn = async (req, res) => {
+  try {
+    await wakeTv();
+    res.send("Encendiendo el televisor...");
+  } catch (err) {
+    console.error("❌ Error al enviar Wake-on-LAN:", err);
+    res.status(500).send("Error al encender el televisor");
+  }
+};
+
 exports.powerOff = (req, res) => {
-  const lgtv = require("../utils/lgtv")();
+  const lgtv = createLgtv();
   lgtv.on("connect", () => {
     lgtv.request("ssap://system/turnOff", (err) => {
       if (err) return res.status(500).send("Error al apagar el televisor");
@@ -20,118 +106,49 @@ exports.powerOff = (req, res) => {
   lgtv.on("error", () => res.status(500).send("Error al conectar con el televisor"));
 };
 
-exports.powerOnAndOpenDisney = (req, res) => {
-  const wol = require("wol");
-  const { MAC_ADDRESS } = require("../config/tv.config");
-
-  wol.wake(MAC_ADDRESS, async (err) => {
-    if (err) {
-      console.error("❌ Error al enviar Wake-on-LAN:", err);
-      return res.status(500).send("Error al encender el televisor");
-    }
-
-    console.log("⚡ Wake-on-LAN enviado. Esperando que inicie webOS...");
-
-    // Esperar 15 segundos para que el televisor termine de iniciar
-    setTimeout(() => {
-      const lgtv = require("../utils/lgtv")();
-
-      lgtv.on("connect", () => {
-        console.log("📺 Conectado. Abriendo Disney+...");
-
-        lgtv.request("ssap://system.launcher/launch", { id: "com.disney.disneyplus-prod" }, (err2) => {
-          if (err2) {
-            console.error("❌ No se pudo abrir Disney+:", err2);
-            res.status(500).send("El TV se encendió, pero no se pudo abrir Disney+");
-          } else {
-            console.log("✅ Disney+ abierto automáticamente después de encender");
-            res.send("TV encendido y Disney+ abierto correctamente");
-          }
-          lgtv.disconnect();
-        });
-      });
-
-      lgtv.on("error", (err3) => {
-        console.error("❌ Error al conectar con el televisor:", err3);
-        res.status(500).send("El TV se encendió, pero no se pudo conectar vía WebSocket");
-      });
-    }, 15000); // 15 segundos
-  });
-};
-
-exports.smartOpenDisney = async (req, res) => {
-  const wol = require("wol");
-  const { MAC_ADDRESS } = require("../config/tv.config");
-
-  // Función para intentar conectar al TV
-  const tryConnect = () => {
-    return new Promise((resolve, reject) => {
-      const lgtv = require("lgtv2")({
-        url: "ws://192.168.18.19:3000",
-        reconnect: false,
-      });
-
-      lgtv.on("connect", () => resolve(lgtv));
-      lgtv.on("error", () => reject(new Error("No se pudo conectar")));
-    });
-  };
-
-  // Función que lanza Disney+
-  const sendDisneyLaunch = (socket) => {
-    socket.request("ssap://system.launcher/launch", { id: "com.disney.disneyplus-prod" }, (err) => {
-      if (err) {
-        console.error("❌ Error al abrir Disney+:", err);
-        res.status(500).send("No se pudo abrir Disney+");
-      } else {
-        res.send("✅ Disney+ abierto correctamente");
-      }
-      socket.disconnect();
-    });
-  };
-
-  // Función que hace timeout manual
-  const timeout = (ms) =>
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("timeout")), ms)
-    );
-
-  // Verificar si el TV ya está encendido (máx 3s)
+exports.powerOnAndOpenDisney = async (req, res) => {
   try {
-    console.log("⚡ Verificando si el TV está encendido (espera 3s máx)...");
-    const lgtv = await Promise.race([tryConnect(), timeout(3000)]);
-    console.log("✅ El TV está encendido. Abriendo Disney+...");
-    sendDisneyLaunch(lgtv);
-  } catch (error) {
-    console.log("🔌 El TV parece estar apagado. Enviando Wake-on-LAN...");
+    console.log("⚡ Enviando Wake-on-LAN...");
+    await wakeTv();
 
-    wol.wake(MAC_ADDRESS, (err2) => {
-      if (err2) {
-        console.error("❌ Error al enviar Wake-on-LAN:", err2);
-        return res.status(500).send("No se pudo encender el televisor");
-      }
+    console.log("⚡ Esperando que webOS termine de iniciar...");
+    const lgtv = await connectWithRetry({ attempts: 10, delayMs: 3000 });
 
-      console.log("⚡ Encendido solicitado. Esperando 10 segundos...");
-
-      setTimeout(() => {
-        const lgtv2 = require("lgtv2")({
-          url: "ws://192.168.18.19:3000",
-          reconnect: false,
-        });
-
-        lgtv2.on("connect", () => {
-          console.log("📺 Conectado después de encender. Abriendo Disney+...");
-          sendDisneyLaunch(lgtv2);
-        });
-
-        lgtv2.on("error", (err3) => {
-          console.error("❌ No se pudo conectar tras el encendido:", err3);
-          res.status(500).send("TV encendido, pero no se pudo conectar para abrir Disney+");
-        });
-      }, 5000); // esperar a que webOS termine de cargar
-    });
+    console.log("📺 Conectado después de encender. Abriendo Disney+...");
+    launchDisney(lgtv, res);
+  } catch (err) {
+    console.error("❌ No se pudo conectar tras el encendido:", err);
+    res.status(500).send("TV encendido, pero no se pudo conectar para abrir Disney+");
   }
 };
 
+exports.smartOpenDisney = async (req, res) => {
+  try {
+    console.log("⚡ Verificando si el TV está encendido (espera 3s máx)...");
+    const lgtv = await Promise.race([
+      connectWithRetry({ attempts: 1, delayMs: 0 }),
+      sleep(3000).then(() => {
+        throw new Error("timeout");
+      }),
+    ]);
 
+    console.log("✅ El TV está encendido. Abriendo Disney+...");
+    launchDisney(lgtv, res);
+    return;
+  } catch (_) {
+    console.log("🔌 El TV parece estar apagado. Enviando Wake-on-LAN...");
+  }
 
+  try {
+    await wakeTv();
+    console.log("⚡ Encendido solicitado. Esperando disponibilidad de webOS...");
 
+    const lgtv = await connectWithRetry({ attempts: 10, delayMs: 3000 });
+
+    console.log("📺 Conectado después de encender. Abriendo Disney+...");
+    launchDisney(lgtv, res);
+  } catch (err) {
+    console.error("❌ No se pudo conectar tras el encendido:", err);
+    res.status(500).send("TV encendido, pero no se pudo conectar para abrir Disney+");
+  }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,12 @@ services:
   app:
     build: .
     container_name: backendwaketv-app
+    network_mode: host
     environment:
       - NODE_ENV=production
-      - PORT=5000
-    ports:
-      - "8081:5000"
+      - PORT=8081
+      - TV_IP=192.168.18.19
+      - TV_MAC_ADDRESS=14:c9:13:7b:b7:14
+      - WOL_BROADCAST_ADDRESS=192.168.18.255
+      - WOL_PORT=9
     restart: unless-stopped

--- a/routes/power.routes.js
+++ b/routes/power.routes.js
@@ -3,12 +3,15 @@ const router = express.Router();
 const powerController = require("../controllers/power.controller");
 
 router.post("/on", powerController.powerOn);
+router.get("/on", powerController.powerOn);
 router.post("/off", powerController.powerOff);
+router.get("/off", powerController.powerOff);
 router.post("/on-disney", powerController.powerOnAndOpenDisney);
+router.get("/on-disney", powerController.powerOnAndOpenDisney);
 router.post("/disney-smart", powerController.smartOpenDisney);
+router.get("/disney-smart", powerController.smartOpenDisney);
 
 
 
 module.exports = router;
-
 


### PR DESCRIPTION
### Motivation

- Wake-on-LAN from the container was not reliably reaching the TV and attempts to connect to the TV websocket returned `EHOSTUNREACH`, so the wake-and-open-Disney flows failed after starting the TV. 
- Endpoints were being invoked via `GET` in practice but only exposed as `POST`, and the TV connection logic was hardcoded and brittle during webOS boot.

### Description

- Update `docker-compose.yml` to use `network_mode: host` and add environment variables for `TV_IP`, `TV_MAC_ADDRESS`, `WOL_BROADCAST_ADDRESS`, `WOL_PORT`, and set `PORT=8081` to ensure WOL broadcast reaches the LAN. 
- Make `config/tv.config.js` read TV IP/MAC and WOL broadcast/port from environment variables with sensible fallbacks. 
- Refactor `controllers/power.controller.js` to centralize WOL sending (`wakeTv`), connect to the TV via `lgtv2` with a `connectWithRetry` mechanism (10 attempts × 3s) and a unified `launchDisney` flow, and remove hardcoded websocket URLs. 
- Expose `GET` handlers for `/power/on`, `/power/off`, `/power/on-disney`, and `/power/disney-smart` in `routes/power.routes.js` in addition to existing `POST` handlers.

### Testing

- Ran `node -e "require('./controllers/power.controller'); require('./routes/power.routes'); console.log('ok')"` which printed `ok`, indicating the refactored modules load without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699276e7ec84833281cb32303d7cdade)